### PR TITLE
fix diagram handling for multicasting containers

### DIFF
--- a/pytimeloop/timeloopfe/v4/processors/to_diagram_processor.py
+++ b/pytimeloop/timeloopfe/v4/processors/to_diagram_processor.py
@@ -319,7 +319,7 @@ class ToDiagramProcessor(Processor):
             for cname in names:
                 node = pydot.Node(
                     cname,
-                    label="..." if "..." in cname else cname,
+                    label='\"...\"' if "..." in cname else cname,
                     **self.get_node_kwargs(**node_kwargs),
                 )
                 sub_cluster.add_node(node)


### PR DESCRIPTION
add escape to the quotes to make sure the generated dot file contains valid string

this is same change migrated from timeloopfe repo: https://github.com/Accelergy-Project/timeloopfe/pull/8