### PR TITLE
[bug fix] Add name field for StorageAttributes

### DIFF
--- a/pytimeloop/timeloopfe/v4/arch.py
+++ b/pytimeloop/timeloopfe/v4/arch.py
@@ -517,6 +517,7 @@ class StorageAttributes(Attributes):
     @classmethod
     def declare_attrs(cls, *args, **kwargs):
         super().declare_attrs(*args, **kwargs)
+        super().add_attr("name", (str, int), None)
         super().add_attr("datawidth", (str, int))
         super().add_attr("technology", (str, int), None)
         super().add_attr("n_banks", (str, int), 2)


### PR DESCRIPTION
Added `name` field for `StorageAttributes`.

When specify the name for a DRAM with current version, like

```
architecture:
  version: 0.4
  nodes:
  - !Container
    name: System
    attributes:
      technology: "40nm"
      global_cycle_seconds: 1e-9

  - !Component
    name: MainMemory
    class: DRAM
    attributes:
      width: 256
      datawidth: 8
```

triggers an error

```
Could not find attribute name in <class 'pytimeloop.timeloopfe.v4.arch.StorageAttributes'>.
```

Just simply add this field can resolve that.