### PR TITLE
[bug fix] Move "depth is None" warning from `StorageAttributes.__init__` to `Storage.__init__`

### DIFF
--- a/pytimeloop/timeloopfe/v4/arch.py
+++ b/pytimeloop/timeloopfe/v4/arch.py
@@ -383,6 +383,8 @@ class Storage(Component):
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)
         self.attributes: StorageAttributes = self["attributes"]
+        if self.attributes.depth is None:
+            print(f'WARNING: "depth" is not set for storage element {self.name}')
 
 
 class Compute(Component):
@@ -587,8 +589,6 @@ class StorageAttributes(Attributes):
         ]
         self.decompression_supported: Union[str, bool] = self["decompression_supported"]
         self.compression_supported: Union[str, bool] = self["compression_supported"]
-        if self.depth is None:
-            print(f'WARNING: "depth" is not set for storage element {self.name}')
 
 
 class Nothing(Component):


### PR DESCRIPTION
**Problem**: The depth warning in `StorageAttributes.__init__` references `self.name`, but `StorageAttributes` inherits from `Attributes` / `DictNode` and does not have a name attribute, causing a potential `AttributeError`.

**Fix**: Move the warning to `Storage.__init__`, which inherits from `Component` → `Leaf`, where `self.name` is properly defined.
